### PR TITLE
perf: restrict keyword matches to top 5 for improved accuracy

### DIFF
--- a/src/be/api.js
+++ b/src/be/api.js
@@ -3,7 +3,6 @@ import { convert } from "adf-to-md";
 import { retext } from "retext";
 import retextPos from "retext-pos";
 import retextKeywords from "retext-keywords";
-import { toString } from "nlcst-to-string";
 
 export async function getKeywordGraphs() {
     const links = []
@@ -39,10 +38,11 @@ export async function getKeywordGraphs() {
                     .use(retextKeywords)
                     .process(body)
 
-                const keywords = []
+                file.data.keywords.sort((a, b) => b.score - a.score || b.matches.length - a.matches.length);
+                const keywords = file.data.keywords.slice(0, 5);
                 if (file.data.keywords) {
-                    for (const keyword of file.data.keywords) {
-                        const word = toString(keyword.matches[0].node) 
+                    for (const keyword of keywords) {
+                        const word = keyword.stem
                         const docIds = keywordMap.get(word)
                         if (docIds) {
                             keywordMap.set(word, [...docIds, d.id])
@@ -56,8 +56,6 @@ export async function getKeywordGraphs() {
                         } else {
                             keywordMap.set(word, [d.id])
                         }
-
-                        keywords.push(word)
                     }
                 }
 


### PR DESCRIPTION
+ 추출된 모든 키워드를 사용하는 것에서, score와 빈도수를 통해 정렬하여 상위 5개 키워드만 이용해 관계를 만들도록 수정합니다. 
+ word값으로 stem을 이용하도록 수정하여 변형된 단어도 같은 단어로 판단할 수 있도록 수정합니다. (ex) times 와 time은 모두 stem이 time)