### PR TITLE
refactor: split UI into components and consolidate data logic into a custom hook

### DIFF
--- a/src/fe/src/App.js
+++ b/src/fe/src/App.js
@@ -1,84 +1,40 @@
-import React, { useEffect, useState } from 'react';
 import './App.css';
-import { invoke, router } from '@forge/bridge';
-import ForceGraph3D from 'react-force-graph-3d';
-import ForceGraph2D from 'react-force-graph-2d';
-import * as THREE from 'three';
-import SpriteText from 'three-spritetext';
-import SearchBar from './components/SearchBar';
-import SwitchButton from "./components/SwitchButton";
-import CheckBox from "./components/Checkbox";
-import { getLinkColor } from './utils/utils';
-import PageNodeTooltip from './components/PageNodeTooltip';
-import SyncBtn from './components/SyncBtn';
-import SyncDescription from './components/SyncDescription';
-import Modal from "./components/Modal";
+
+import React, { useEffect, useState } from 'react';
+import { invoke } from '@forge/bridge';
+
 import DarkmodeBtn from "./components/DarkmodeBtn";
+import GraphContainer from "./components/GraphContainer";
+import GraphControls from "./components/GraphControls";
+import LoadingScreen from "./components/LoadingScreen";
+import Modal from "./components/Modal";
+import SearchBar from "./components/SearchBar";
 import SyncConfirmModal from './components/SyncConfirmModal';
+import SyncDescription from './components/SyncDescription';
+import useGraphData from "./hooks/useGraphData";
+import { getLinkColor } from './utils/utils';
 
 function App() {
   const [appWidth, setAppWidth] = useState(window.innerWidth);
   const [graphData, setGraphData] = useState({ nodes: [], links: [] });
+  const [linkColor, setLinkColor] = useState({ keyword: getLinkColor('keyword'), hierarchy: getLinkColor('hierarchy'), labels: getLinkColor('labels'), rovo: getLinkColor('rovo')});
   const [checkbox, setCheckbox] = useState({keyword: false, hierarchy: false, labels: false, rovo: false});
-  const [linkColor, setLinkColor] = useState({ keyword: getLinkColor('keyword'), hierarchy: getLinkColor('hierarchy'), labels: getLinkColor('labels'), rovo: getLinkColor('rovo')})
-  const [nodes, setNodes] = useState([]);
-  const [keyword, setKeyword] = useState([]);
-  const [hierarchy, setHierarchy] = useState([]);
-  const [labels, setLabels] = useState([]);
-  const [rovos, setRovos] = useState([]);
-  const [is3D, setIs3D] = useState(false)
-  const [isSearching, setIsSearching] = useState(false);
   const [searchWord, setSearchWord] = useState('');
-  const [tooltipContent, setTooltipContent] = useState(null);
+  const [isSearching, setIsSearching] = useState(false);
   const [showRovoModal, setShowRovoModal] = useState(false);
   const [showSyncModal, setShowSyncModal] = useState(false);
+  const [is3D, setIs3D] = useState(false);
   const [isDarkMode, setDarkMode] = useState(() => {
     return localStorage.getItem('doculinkDarkmode') === 'true';
   });
-
-  useEffect(async () => {
-    setIsSearching(true);
-    try{
-      const result = await invoke('getNodes');
-      console.log('nodes',result);
-      setNodes(result)
-    } finally {
-      setIsSearching(false);
-    }
-  }, []);
-
-  useEffect(async () => {
-    const result = await invoke('getKeywordGraphs');
-    setKeyword(result)
-  }, []);
-
-  useEffect(async () => {
-    const result = await invoke('getHierarchy');
-    setHierarchy(result)
-  }, []);
-
-  useEffect(async () => {
-    try{
-      const result = await invoke('getLabels');
-      setLabels(result)
-    } finally {
-    }
-  }, []);
-
-  useEffect(async () => {
-    try {
-      const result = await invoke('getRovoKeywords');
-      setRovos(result)
-    } finally {
-    }
-  }, []);
+  const { nodes, setNodes, keyword, setKeyword, hierarchy, setHierarchy, label, setLabel, rovo, setRovo } = useGraphData();
 
   const handleSearch = async () => {
     setIsSearching(true);
     try {
       const searchedPageIdList = await invoke('searchByAPI', { searchWord });
       let newNodes = []
-      for(const node of nodes) {
+      for (const node of nodes) {
         node.searched = searchedPageIdList.includes(node.id);
         newNodes.push(node);
       }
@@ -87,43 +43,19 @@ function App() {
       setIsSearching(false);
     }
   };
-
-  const handleSearchReset = async () => {
+  const handleSearchReset = () => {
     let newNodes = []
-    for(const node of nodes) {
+    for (const node of nodes) {
       node.searched = false;
       newNodes.push(node);
     }
     setNodes(newNodes);
   };
-
-  // checkbox example event
-  const handleCheckbox = (key, checked) => {
-    let newCheckbox = {...checkbox};
-    if(key === "keyword") {
-      newCheckbox.keyword = checked;
-    } else if(key === "page hierarchy") {
-      newCheckbox.hierarchy = checked;
-    } else if (key === "labels") {
-      newCheckbox.labels = checked;
-    } else if (key === "rovo") {
-      newCheckbox.rovo = checked;
-    }
-
-    setCheckbox(newCheckbox);
-  };
-  const handleLinkColor = (key, color) => {
-    let newLinkColor = {...linkColor};
-    console.log(key, color);
-    newLinkColor[key] = color;
-    setLinkColor(newLinkColor);
-  }
-
   useEffect(() => {
     let graph = {
       nodes: nodes,
       links: [],
-    }
+    };
 
     if (checkbox.keyword) {
       graph.links.push(...keyword);
@@ -132,14 +64,14 @@ function App() {
       graph.links.push(...hierarchy);
     }
     if (checkbox.labels) {
-      graph.links.push(...labels);
+      graph.links.push(...label);
     }
 
     if (checkbox.rovo) {
-      if (!rovos) {
+      if (!rovo) {
         setShowRovoModal(true);
       } else {
-        graph.links.push(...rovos);
+        graph.links.push(...rovo);
       }
     }
     setGraphData(graph);
@@ -154,19 +86,15 @@ function App() {
     return () => window.removeEventListener('resize', handleResize);
   }, []);
 
-  const handleSync = async () => {
-    setShowSyncModal(true);
-  };
-
   const handleSyncConfirm = async () => {
     setShowSyncModal(false);
     setIsSearching(true);
     try {
       const result = await invoke('sync');
-      setNodes(result.nodes)
-      setKeyword(result.keyword)
-      setHierarchy(result.hierarchy)
-      setLabels(result.labels)
+      setNodes(result.nodes);
+      setKeyword(result.keyword);
+      setHierarchy(result.hierarchy);
+      setLabel(result.labels);
       
       // Reset the links and checkboxes
       setGraphData({ nodes: result.nodes, links: [] });
@@ -181,9 +109,6 @@ function App() {
     }
   };
 
-  const nodeColor = isDarkMode ? '#ffffff' : '#525252';
-  const backgroundColor = isDarkMode ? 'black' : 'lightgrey';
-
   return (
       <div>
         <div>
@@ -196,187 +121,24 @@ function App() {
                   handleSearchReset={handleSearchReset}
               />
             </div>
-            <div className='absolute z-20 right-[1rem] top-[5rem] space-y-2'>
-              <SwitchButton
-                  is3D={is3D}
-                  setIs3D={setIs3D}
-              />
-              <CheckBox
-                  title='keyword'
-                  colorKey='keyword'
-                  onChecked={handleCheckbox}
-                  onColorChange={handleLinkColor}
-                  tooltip='Connect pages by keyword'
-                  color={linkColor.keyword}
-                  checked={checkbox.keyword}
-              />
-              <CheckBox
-                  title='rovo'
-                  colorKey='rovo'
-                  onChecked={handleCheckbox}
-                  onColorChange={handleLinkColor}
-                  tooltip='Connect pages by rovo'
-                  color={linkColor.rovo}
-                  checked={checkbox.rovo}
-              />
-              <CheckBox
-                  title='page hierarchy'
-                  colorKey='hierarchy'
-                  onChecked={handleCheckbox}
-                  onColorChange={handleLinkColor}
-                  tooltip='Connect pages by page hierarchy'
-                  color={linkColor.hierarchy}
-                  checked={checkbox.hierarchy}
-              />
-              <CheckBox
-                  title='labels'
-                  colorKey='labels'
-                  onChecked={handleCheckbox}
-                  onColorChange={handleLinkColor}
-                  tooltip='Connect pages by page labels'
-                  color={linkColor.labels}
-                  checked={checkbox.labels}
-              />
-            </div>
-            <div className='absolute z-10 right-[1rem] top-[16rem]'>
-              <SyncBtn handleSync={handleSync}/>
-            </div>
+            <GraphControls
+                is3D={is3D}
+                setIs3D={setIs3D}
+                checkbox={checkbox}
+                handleCheckbox={(key, checked) => setCheckbox(prev => ({ ...prev, [key]: checked }))}
+                linkColor={linkColor}
+                handleLinkColor={(key, color) => setLinkColor(prev => ({ ...prev, [key]: color }))}
+                handleSync={() => setShowSyncModal(true)}
+            />
           </div>
-          {isSearching && (
-              <div className="absolute inset-0 z-20 flex items-center justify-center bg-black bg-opacity-50">
-                <div className="animate-pulse flex flex-col items-center space-y-4">
-                  <div className="text-slate-600 text-xl font-medium">DocuLink</div>
-                  <div className="flex-1 space-y-6 py-1">
-                    <div className="h-2 bg-slate-600 rounded w-24"></div>
-                    <div className="space-y-2">
-                      <div className="grid grid-cols-3 gap-4">
-                        <div className="h-2 bg-slate-600 rounded col-span-2"></div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-          )}
-          {tooltipContent && (
-              <PageNodeTooltip
-                  title={tooltipContent.title}
-                  status={tooltipContent.status}
-                  createdAt={tooltipContent.createdAt}
-                  authorName={tooltipContent.authorName}
-              />
-          )
-          }
-          { is3D ?
-              <ForceGraph3D
-                  graphData={graphData}
-                  width={appWidth}
-                  height={800}
-                  linkOpacity={0.8}
-                  linkColor={link=> {
-                    if (link.type === 'keyword') {
-                      return linkColor.keyword
-                    } else if (link.type === 'hierarchy') {
-                      return linkColor.hierarchy
-                    } else if (link.type === 'labels') {
-                      return linkColor.labels
-                    } else if (link.type === 'rovo') {
-                      return linkColor.rovo
-                    }
-                    return getLinkColor(link.type)
-                  }}
-                  backgroundColor={backgroundColor}
-                  controlType={'orbit'}
-                  nodeThreeObject={node => {
-                    const radius = node.searched ? 10 : 8;
-                    const color = node.searchded ? '#ffde21' : nodeColor;
-                    const geometry = new THREE.SphereGeometry(radius, 16, 16);
-                    const material = new THREE.MeshBasicMaterial({ color });
-
-                    return new THREE.Mesh(geometry, material);
-                  }}
-                  onNodeClick={(node) => {
-                    if (node.url) {
-                      router.open(node.url);
-                    }
-                  }}
-                  onNodeHover={(node, prevNode) => {
-                    if (node) {
-                      setTooltipContent({
-                        title: node.title,
-                        authorName: node.authorName,
-                        createdAt: node.createdAt,
-                        status: node.status,
-                      });
-                    } else {
-                      setTooltipContent(null);
-                    }
-                  }}
-              /> :
-              <ForceGraph2D
-                  graphData={graphData}
-                  width={appWidth}
-                  height={800}
-                  linkColor={link=> {
-                    if (link.type === 'keyword') {
-                      return linkColor.keyword
-                    } else if (link.type === 'hierarchy') {
-                      return linkColor.hierarchy
-                    } else if (link.type === 'labels') {
-                      return linkColor.labels
-                    } else if (link.type === 'rovo') {
-                      return linkColor.rovo
-                    }
-                    return getLinkColor(link.type)
-                  }}
-                  backgroundColor={backgroundColor}
-                  nodeCanvasObject={(node, ctx, globalScale) => {
-                    const label = node.title;
-                    const fontSize = 9 / globalScale;
-                    const textWidth = ctx.measureText(label).width;
-                    const bckgDimensions = [textWidth, fontSize].map(n => 2*n); // some padding'
-                    const radius = node.searched ? 10 : 8;
-
-                    node.searched ? ctx.fillStyle = 'rgba(255, 222, 33, 0.8)' : ctx.fillStyle = nodeColor;
-
-                    ctx.textAlign = 'center';
-                    ctx.textBaseline = 'middle';
-                    ctx.fillStyle = node.color;
-                    ctx.font = `${fontSize * 1.5}px system-ui`;
-
-                    ctx.beginPath();
-                    ctx.arc(node.x, node.y, radius, 0, 2 * Math.PI, false);
-                    ctx.fill();
-
-                    if (fontSize < 5) {
-                      ctx.fillText(label, node.x, node.y + (node.searched ? 15 : 13));
-                    }
-
-                    node.__bckgDimensions = bckgDimensions; // to re-use in nodePointerAreaPaint
-                  }}
-                  nodePointerAreaPaint={(node, color, ctx) => {
-                    ctx.fillStyle = color;
-                    const bckgDimensions = node.__bckgDimensions;
-                    bckgDimensions && ctx.fillRect(node.x - bckgDimensions[0] / 2, node.y - bckgDimensions[1] / 2, ...bckgDimensions);
-                  }}
-                  onNodeClick={(node) => {
-                    if (node.url) {
-                      router.open(node.url);
-                    }
-                  }}
-                  onNodeHover={(node, prevNode) => {
-                    if (node) {
-                      setTooltipContent({
-                        title: node.title,
-                        authorName: node.authorName,
-                        createdAt: node.createdAt,
-                        status: node.status,
-                      });
-                    } else {
-                      setTooltipContent(null);
-                    }
-                  }}
-              />
-          }
+          <LoadingScreen isVisible={isSearching} />
+          <GraphContainer
+            is3D={is3D}
+            graphData={graphData}
+            appWidth={appWidth}
+            isDarkMode={isDarkMode}
+            linkColor={linkColor}
+          />
         </div>
         <SyncDescription />
         <Modal

--- a/src/fe/src/components/Checkbox.jsx
+++ b/src/fe/src/components/Checkbox.jsx
@@ -2,11 +2,11 @@ import React from 'react';
 
 import LinkColor from "./LinkColor";
 
-function CheckBox({ title, colorKey, onChecked, onColorChange, tooltip, color, checked }) {
+function CheckBox({ title, keyName, onChecked, onColorChange, tooltip, color, checked }) {
   const handleChange = (e) => {
     const newChecked = e.target.checked;
     if (onChecked) {
-        onChecked(title, newChecked);
+        onChecked(keyName, newChecked);
     }
   };
 
@@ -21,7 +21,7 @@ function CheckBox({ title, colorKey, onChecked, onColorChange, tooltip, color, c
           className='w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded-lg focus:ring-blue-500 focus:ring-2'
         />
         <label htmlFor={`${title}-checkbox`} className={`px-2 text-sm font-medium capitalize ${checked ? 'dark:text-yellow-300 text-purple-600' : 'dark:text-white text-gray-600'}`}>{title}</label>
-        <LinkColor colorKey={colorKey} onChange={onColorChange} color={color} />
+        <LinkColor colorKey={keyName} onChange={onColorChange} color={color} />
       </div>
       {tooltip && (
           <span className="absolute right-full top-1/2 transform -translate-y-1/2 mr-3 px-2 py-1 bg-gray-50 text-gray-500 dark:bg-gray-800 dark:text-white text-xs rounded opacity-0 group-hover:opacity-100 transition-opacity duration-300 whitespace-nowrap">

--- a/src/fe/src/components/Graph.jsx
+++ b/src/fe/src/components/Graph.jsx
@@ -1,0 +1,95 @@
+import React, { useCallback } from 'react'
+import * as THREE from "three";
+import { router } from "@forge/bridge";
+import ForceGraph3D from "react-force-graph-3d";
+import ForceGraph2D from "react-force-graph-2d";
+
+import { getLinkColor } from "../utils/utils";
+
+function Graph({ is3D, graphData, width, height, backgroundColor, linkColor, nodeColor, setTooltipContent }) {
+    const resolveLinkColor = useCallback((type) => {
+        return linkColor[type] ?? getLinkColor(type);
+    }, [linkColor]);
+
+    const handleNodeClick = (node) => {
+        if (node.url) {
+            router.open(node.url);
+        }
+    };
+
+    const handleNodeHover = (node) => {
+        if (node) {
+            setTooltipContent({
+                title: node.title,
+                authorName: node.authorName,
+                createdAt: node.createdAt,
+                status: node.status,
+            });
+        } else {
+            setTooltipContent(null);
+        }
+    };
+
+    return is3D ? (
+        <ForceGraph3D
+            graphData={graphData}
+            width={width}
+            height={height}
+            linkOpacity={0.8}
+            controlType={'orbit'}
+            backgroundColor={backgroundColor}
+            onNodeClick={handleNodeClick}
+            onNodeHover={handleNodeHover}
+            linkColor={(link) => resolveLinkColor(link.type)}
+            nodeThreeObject={(node) => {
+                const radius = node.searched ? 10 : 8;
+                const color = node.searched ? '#ffde21' : nodeColor;
+                const geometry = new THREE.SphereGeometry(radius, 16, 16);
+                const material = new THREE.MeshBasicMaterial({ color });
+
+                return new THREE.Mesh(geometry, material);
+            }}
+        />
+    ) : (
+        <ForceGraph2D
+            graphData={graphData}
+            width={width}
+            height={height}
+            backgroundColor={backgroundColor}
+            onNodeClick={handleNodeClick}
+            onNodeHover={handleNodeHover}
+            linkColor={(link) => resolveLinkColor(link.type)}
+            nodeCanvasObject={(node, ctx, globalScale) => {
+                const label = node.title;
+                const fontSize = 9 / globalScale;
+                const textWidth = ctx.measureText(label).width;
+                const bckgDimensions = [textWidth, fontSize].map(n => 2*n); // some padding'
+                const radius = node.searched ? 10 : 8;
+
+                node.searched ? ctx.fillStyle = 'rgba(255, 222, 33, 0.8)' : ctx.fillStyle = nodeColor;
+
+                ctx.textAlign = 'center';
+                ctx.textBaseline = 'middle';
+                ctx.fillStyle = node.color;
+                ctx.font = `${fontSize * 1.5}px system-ui`;
+
+                ctx.beginPath();
+                ctx.arc(node.x, node.y, radius, 0, 2 * Math.PI, false);
+                ctx.fill();
+
+                if (fontSize < 5) {
+                    ctx.fillText(label, node.x, node.y + (node.searched ? 15 : 13));
+                }
+
+                node.__bckgDimensions = bckgDimensions;
+            }}
+            nodePointerAreaPaint={(node, color, ctx) => {
+                ctx.fillStyle = color;
+                const bckgDimensions = node.__bckgDimensions;
+                bckgDimensions && ctx.fillRect(node.x - bckgDimensions[0] / 2, node.y - bckgDimensions[1] / 2, ...bckgDimensions);
+            }}
+        />
+    );
+}
+
+export default Graph;

--- a/src/fe/src/components/GraphContainer.jsx
+++ b/src/fe/src/components/GraphContainer.jsx
@@ -1,0 +1,34 @@
+import { useState } from "react";
+
+import PageNodeTooltip from "./PageNodeTooltip";
+import Graph from "./Graph";
+
+function GraphContainer({ is3D, graphData, appWidth, isDarkMode, linkColor }) {
+    const [tooltipContent, setTooltipContent] = useState(null);
+    const nodeColor = isDarkMode ? '#ffffff' : '#525252';
+    const backgroundColor = isDarkMode ? 'black' : 'lightgrey';
+    return (
+        <>
+            <Graph
+                is3D={is3D}
+                graphData={graphData}
+                width={appWidth}
+                height={800}
+                backgroundColor={backgroundColor}
+                linkColor={linkColor}
+                nodeColor={nodeColor}
+                setTooltipContent={setTooltipContent}
+            />
+            {tooltipContent && (
+                <PageNodeTooltip
+                    title={tooltipContent.title}
+                    status={tooltipContent.status}
+                    createdAt={tooltipContent.createdAt}
+                    authorName={tooltipContent.authorName}
+                />
+            )}
+        </>
+    )
+}
+
+export default GraphContainer;

--- a/src/fe/src/components/GraphControls.jsx
+++ b/src/fe/src/components/GraphControls.jsx
@@ -1,0 +1,62 @@
+import CheckBox from "./Checkbox";
+import SwitchButton from "./SwitchButton";
+import SyncBtn from "./SyncBtn";
+
+function GraphControls({
+    is3D, setIs3D,
+    checkbox, handleCheckbox,
+    linkColor, handleLinkColor,
+    handleSync
+}) {
+    return (
+        <>
+            <div className='absolute z-20 right-[1rem] top-[5rem] space-y-2'>
+                <SwitchButton
+                    is3D={is3D}
+                    setIs3D={setIs3D}
+                />
+                <CheckBox
+                    title='keyword'
+                    keyName='keyword'
+                    onChecked={handleCheckbox}
+                    onColorChange={handleLinkColor}
+                    tooltip='Connect pages by keyword'
+                    color={linkColor.keyword}
+                    checked={checkbox.keyword}
+                />
+                <CheckBox
+                    title='rovo'
+                    keyName='rovo'
+                    onChecked={handleCheckbox}
+                    onColorChange={handleLinkColor}
+                    tooltip='Connect pages by rovo'
+                    color={linkColor.rovo}
+                    checked={checkbox.rovo}
+                />
+                <CheckBox
+                    title='page hierarchy'
+                    keyName='hierarchy'
+                    onChecked={handleCheckbox}
+                    onColorChange={handleLinkColor}
+                    tooltip='Connect pages by page hierarchy'
+                    color={linkColor.hierarchy}
+                    checked={checkbox.hierarchy}
+                />
+                <CheckBox
+                    title='labels'
+                    keyName='labels'
+                    onChecked={handleCheckbox}
+                    onColorChange={handleLinkColor}
+                    tooltip='Connect pages by page labels'
+                    color={linkColor.labels}
+                    checked={checkbox.labels}
+                />
+            </div>
+            <div className='absolute z-10 right-[1rem] top-[16rem]'>
+                <SyncBtn handleSync={handleSync}/>
+            </div>
+        </>
+    )
+}
+
+export default GraphControls;

--- a/src/fe/src/components/LoadingScreen.jsx
+++ b/src/fe/src/components/LoadingScreen.jsx
@@ -1,0 +1,21 @@
+function LoadingScreen({ isVisible }) {
+    if (!isVisible) return null;
+
+    return (
+        <div className="absolute inset-0 z-20 flex items-center justify-center bg-black bg-opacity-50">
+            <div className="animate-pulse flex flex-col items-center space-y-4">
+                <div className="text-slate-600 text-xl font-medium">DocuLink</div>
+                <div className="flex-1 space-y-6 py-1">
+                    <div className="h-2 bg-slate-600 rounded w-24"></div>
+                    <div className="space-y-2">
+                        <div className="grid grid-cols-3 gap-4">
+                            <div className="h-2 bg-slate-600 rounded col-span-2"></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    )
+}
+
+export default LoadingScreen;

--- a/src/fe/src/hooks/useGraphData.js
+++ b/src/fe/src/hooks/useGraphData.js
@@ -1,0 +1,48 @@
+import { useEffect, useState } from "react";
+import { invoke } from "@forge/bridge";
+
+async function loadData(fetchFn, setState, setLoading) {
+    if (setLoading) setLoading(true);
+    try {
+        const result = await fetchFn();
+        setState(result);
+    } finally {
+        if (setLoading) setLoading(false);
+    }
+}
+
+function useGraphData(setIsSearching) {
+    const [nodes, setNodes] = useState([]);
+    const [keyword, setKeyword] = useState([]);
+    const [hierarchy, setHierarchy] = useState([]);
+    const [label, setLabel] = useState([]);
+    const [rovo, setRovo] = useState([]);
+
+    // fetching node
+    useEffect(() => {
+        loadData(() => invoke('getNodes'), setNodes, setIsSearching);
+    }, []);
+
+    // fetching keyword link
+    useEffect(() => {
+        loadData(() => invoke('getKeywordGraphs'), setKeyword, undefined);
+    }, []);
+
+    // fetching hierarchy link
+    useEffect(() => {
+        loadData(() => invoke('getHierarchy'), setHierarchy, undefined);
+    }, []);
+
+    // fetching label link
+    useEffect(() => {
+        loadData(() => invoke('getLabels'), setLabel, undefined);
+    }, []);
+
+    useEffect(() => {
+        loadData(() => invoke('getRovoKeywords'), setRovo, undefined);
+    }, []);
+
+    return { nodes, setNodes, keyword, setKeyword, hierarchy, setHierarchy, label, setLabel, rovo, setRovo };
+}
+
+export default useGraphData;


### PR DESCRIPTION
App.js 파일의 component와 state를 나눠서 관리해 가독성을 높입니다. 변경사항은 다음과 같습니다.
+ node, keyword, hierarchy, label, rovo를 `useGraphData` 훅을 통해 한번에 관리합니다.
  + 이때 label, rovo만 s가 붙어 있어 통일성을 맞추기 위해 변수명에 s를 제거합니다. 
+ 관계를 나타내는 `ForeceGraph3D`와 `ForceGraph2D`를 `Graph` 컴포넌트로 관리합니다.
+ `PageNodeTooltip`과 `Graph`를  `GraphContainer` 컴포넌트로 관리합니다.
+ Sync 혹은 검색, 로딩에 사용되는 화면을 `LoadingScreen` 컴포넌트로 관리합니다.
+ `SwitchButton`, `Checkbox`, `SyncBtn`을 `GraphControls` 컴포넌트로 관리합니다.
+ `handleCheckbox`, `handleLinkColor`가 같은 키 값을 사용하도록 `page hierarchy`를 `hierarchy`로 수정합니다. (화면에 보여지는 값은 동일)